### PR TITLE
FileWatcher runnable as a Windows service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,4 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+/FileWatcher/Properties/launchSettings.json

--- a/FileWatcher.sln
+++ b/FileWatcher.sln
@@ -1,20 +1,55 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.32112.339
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FileWatcher", "FileWatcher\FileWatcher.csproj", "{F46457BB-E373-462E-8E5A-8EE669A4B57A}"
 EndProject
+Project("{B7DD6F7E-DEF8-4E67-B5B7-07EF123DB6F0}") = "FwInstaller", "FwInstaller\FwInstaller.wixproj", "{7ABA5E77-930C-490D-A73B-556589F70F6E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|ARM64 = Debug|ARM64
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|ARM64 = Release|ARM64
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{F46457BB-E373-462E-8E5A-8EE669A4B57A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F46457BB-E373-462E-8E5A-8EE669A4B57A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F46457BB-E373-462E-8E5A-8EE669A4B57A}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{F46457BB-E373-462E-8E5A-8EE669A4B57A}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{F46457BB-E373-462E-8E5A-8EE669A4B57A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F46457BB-E373-462E-8E5A-8EE669A4B57A}.Debug|x64.Build.0 = Debug|Any CPU
+		{F46457BB-E373-462E-8E5A-8EE669A4B57A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F46457BB-E373-462E-8E5A-8EE669A4B57A}.Debug|x86.Build.0 = Debug|Any CPU
 		{F46457BB-E373-462E-8E5A-8EE669A4B57A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F46457BB-E373-462E-8E5A-8EE669A4B57A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F46457BB-E373-462E-8E5A-8EE669A4B57A}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{F46457BB-E373-462E-8E5A-8EE669A4B57A}.Release|ARM64.Build.0 = Release|Any CPU
+		{F46457BB-E373-462E-8E5A-8EE669A4B57A}.Release|x64.ActiveCfg = Release|Any CPU
+		{F46457BB-E373-462E-8E5A-8EE669A4B57A}.Release|x64.Build.0 = Release|Any CPU
+		{F46457BB-E373-462E-8E5A-8EE669A4B57A}.Release|x86.ActiveCfg = Release|Any CPU
+		{F46457BB-E373-462E-8E5A-8EE669A4B57A}.Release|x86.Build.0 = Release|Any CPU
+		{7ABA5E77-930C-490D-A73B-556589F70F6E}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{7ABA5E77-930C-490D-A73B-556589F70F6E}.Debug|Any CPU.Build.0 = Debug|x64
+		{7ABA5E77-930C-490D-A73B-556589F70F6E}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{7ABA5E77-930C-490D-A73B-556589F70F6E}.Debug|ARM64.Build.0 = Debug|ARM64
+		{7ABA5E77-930C-490D-A73B-556589F70F6E}.Debug|x64.ActiveCfg = Debug|x64
+		{7ABA5E77-930C-490D-A73B-556589F70F6E}.Debug|x64.Build.0 = Debug|x64
+		{7ABA5E77-930C-490D-A73B-556589F70F6E}.Debug|x86.ActiveCfg = Debug|x86
+		{7ABA5E77-930C-490D-A73B-556589F70F6E}.Debug|x86.Build.0 = Debug|x86
+		{7ABA5E77-930C-490D-A73B-556589F70F6E}.Release|Any CPU.ActiveCfg = Release|x64
+		{7ABA5E77-930C-490D-A73B-556589F70F6E}.Release|Any CPU.Build.0 = Release|x64
+		{7ABA5E77-930C-490D-A73B-556589F70F6E}.Release|ARM64.ActiveCfg = Release|ARM64
+		{7ABA5E77-930C-490D-A73B-556589F70F6E}.Release|ARM64.Build.0 = Release|ARM64
+		{7ABA5E77-930C-490D-A73B-556589F70F6E}.Release|x64.ActiveCfg = Release|x64
+		{7ABA5E77-930C-490D-A73B-556589F70F6E}.Release|x64.Build.0 = Release|x64
+		{7ABA5E77-930C-490D-A73B-556589F70F6E}.Release|x86.ActiveCfg = Release|x86
+		{7ABA5E77-930C-490D-A73B-556589F70F6E}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/FileWatcher/Configuration/XmlFile.cs
+++ b/FileWatcher/Configuration/XmlFile.cs
@@ -55,7 +55,7 @@ namespace TE.FileWatcher.Configuration
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"The folder name is null or empty. Couldn't get the current location. Reason: {ex.Message}");
+                    Console.Error.WriteLine($"The folder name is null or empty. Couldn't get the current location. Reason: {ex.Message}");
                     return null;
                 }
             }
@@ -66,7 +66,7 @@ namespace TE.FileWatcher.Configuration
             }
             else
             {
-                Console.WriteLine("The folder does not exist.");
+                Console.Error.WriteLine("The folder does not exist.");
                 return null;
             }
         }
@@ -106,13 +106,13 @@ namespace TE.FileWatcher.Configuration
                 }
                 else
                 {
-                    Console.WriteLine($"The configuration file '{fullPath}' was not found.");
+                    Console.Error.WriteLine($"The configuration file '{fullPath}' was not found.");
                     return null;
                 }
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Could not get the path to the configuration file. Reason: {ex.Message}");
+                Console.Error.WriteLine($"Could not get the path to the configuration file. Reason: {ex.Message}");
                 return null;
             }
         }
@@ -129,13 +129,13 @@ namespace TE.FileWatcher.Configuration
         {
             if (string.IsNullOrWhiteSpace(_fullPath))
             {
-                Console.WriteLine("The configuration file path was null or empty.");
+                Console.Error.WriteLine("The configuration file path was null or empty.");
                 return null;
             }
 
             if (!File.Exists(_fullPath))
             {
-                Console.WriteLine($"The configuration file path '{_fullPath}' does not exist.");
+                Console.Error.WriteLine($"The configuration file path '{_fullPath}' does not exist.");
                 return null;
             }
 
@@ -147,7 +147,7 @@ namespace TE.FileWatcher.Configuration
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"The configuration file could not be read. Reason: {ex.Message}");
+                Console.Error.WriteLine($"The configuration file could not be read. Reason: {ex.Message}");
                 return null;
             }
         }

--- a/FileWatcher/Configuration/XmlFile.cs
+++ b/FileWatcher/Configuration/XmlFile.cs
@@ -31,7 +31,7 @@ namespace TE.FileWatcher.Configuration
         /// If the <paramref name="name"/> parameter is <c>null</c>, then the
         /// value of <see cref="DEFAULT_CONFIG_FILE"/>.
         /// </remarks>
-        public XmlFile(string path, string name)
+        public XmlFile(string? path, string? name)
         {
             _fullPath = GetFullPath(path, name);
         }
@@ -83,7 +83,7 @@ namespace TE.FileWatcher.Configuration
         /// <returns>
         /// The full path to the configuration file, otherwise <c>null</c>.
         /// </returns>
-        private static string? GetFullPath(string path, string name)
+        private static string? GetFullPath(string? path, string? name)
         {
             string? folderPath = GetFolderPath(path);
             if (folderPath == null)

--- a/FileWatcher/FileWatcher.csproj
+++ b/FileWatcher/FileWatcher.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>    
     <RootNamespace>TE.FileWatcher</RootNamespace>
     <AssemblyName>fw</AssemblyName>
-    <Version>1.4.0</Version>
+    <Version>1.4.90</Version>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
     <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
@@ -23,9 +23,9 @@
     <PackageTags>filesystem file-monitoring folder-monitoring</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageId>TE.FileWatcher</PackageId>   
+    <PackageId>TE.FileWatcher</PackageId>
   </PropertyGroup>
-
+  
   <ItemGroup>
     <None Include="..\README.md">
       <Pack>True</Pack>
@@ -34,12 +34,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21216.1" />
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		<ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+	</None>
     <None Update="Templates\config-template.xml">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </None>

--- a/FileWatcher/Logging/Logger.cs
+++ b/FileWatcher/Logging/Logger.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
 
 namespace TE.FileWatcher.Logging
 {
@@ -358,7 +359,7 @@ namespace TE.FileWatcher.Logging
                     lock (locker)
                     {
                         RolloverLog();
-                        using StreamWriter writer = new(LogFullPath, true, System.Text.Encoding.UTF8);
+                        using StreamWriter writer = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? new(LogFullPath, true, System.Text.Encoding.UTF8) : new(LogFullPath, true);
                         writer.WriteLine($"{DateTime.Now:yyyy-MM-dd HH:mm:ss} {message.LevelString} {message.Value}");
                     }
                 }

--- a/FileWatcher/Logging/Logger.cs
+++ b/FileWatcher/Logging/Logger.cs
@@ -358,7 +358,7 @@ namespace TE.FileWatcher.Logging
                     lock (locker)
                     {
                         RolloverLog();
-                        using StreamWriter writer = new(LogFullPath, true);
+                        using StreamWriter writer = new(LogFullPath, true, System.Text.Encoding.UTF8);
                         writer.WriteLine($"{DateTime.Now:yyyy-MM-dd HH:mm:ss} {message.LevelString} {message.Value}");
                     }
                 }

--- a/FileWatcher/Program.cs
+++ b/FileWatcher/Program.cs
@@ -3,13 +3,21 @@ using System.CommandLine.Invocation;
 using System.Diagnostics.CodeAnalysis;
 using TE.FileWatcher.Configuration;
 using TE.FileWatcher.Logging;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting.WindowsServices;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;
+using System.CommandLine.IO;
+using System.Text;
+using System;
 
 namespace TE.FileWatcher
 {
     /// <summary>
     /// The main program class.
     /// </summary>
-    class Program
+    internal class Program
     {
         // Success return code
         private const int SUCCESS = 0;
@@ -29,6 +37,27 @@ namespace TE.FileWatcher
         [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "<Pending>")]
         static int Main(string[] args)
         {
+            if (WindowsServiceHelpers.IsWindowsService())
+            {
+                return ServiceMain(args);
+            }
+            else
+            {
+                return InitWatcher(args);
+            }
+        }
+
+        /// <summary>
+        /// Sets up the RootCommand, which parses the command line and runs the filewatcher.
+        /// This is both used directly from Main, but also indirectly from the service, if running as a Windows Service.
+        /// </summary>
+        /// <param name="args"></param>
+        /// <param name="stoppingToken"></param>
+        /// <param name="console"></param>
+        /// <returns></returns>
+        [RequiresUnreferencedCode("Calls TE.FileWatcher.Configuration.IConfigurationFile.Read()")]
+        public static int InitWatcher(string[] args, CancellationToken? stoppingToken = null, WindowsBackgroundService.LoggingConsole? console = null)
+        {
             RootCommand rootCommand = new()
             {
                 new Option<string>(
@@ -39,10 +68,20 @@ namespace TE.FileWatcher
                     aliases: new string[] { "--configFile", "-cf" },
                     description: "The name of the configuration XML file."),
             };
+            if (stoppingToken != null)
+            {
+                rootCommand.AddOption(new Option<CancellationToken?>(
+                    alias: "--stoppingToken",
+                    getDefaultValue: () => stoppingToken,
+                    description: "CancellationToken")
+                    { IsHidden = true }
+                );
+            }
             rootCommand.Description = "Monitors files and folders for changes.";
-            rootCommand.Handler = CommandHandler.Create<string, string>(Run);
+            rootCommand.Handler = CommandHandler.Create<string, string, CancellationToken?>(Run);
 
-            return rootCommand.Invoke(args);
+            rootCommand.TreatUnmatchedTokensAsErrors = true;
+            return rootCommand.Invoke(args, console);
         }
 
         /// <summary>
@@ -58,7 +97,7 @@ namespace TE.FileWatcher
         /// Returns 0 if no error occurred, otherwise non-zero.
         /// </returns>
         [RequiresUnreferencedCode("Calls TE.FileWatcher.Configuration.IConfigurationFile.Read()")]
-        private static int Run(string folder, string configFile)
+        internal static int Run(string? folder, string? configFile, CancellationToken? stoppingToken = null)
         {            
             IConfigurationFile config = new XmlFile(folder, configFile);
 
@@ -76,7 +115,7 @@ namespace TE.FileWatcher
             }
 
             // Run the watcher tasks
-            if (StartWatchers(watches))
+            if (StartWatchers(watches, stoppingToken))
             {
                 return SUCCESS;
             }
@@ -84,6 +123,37 @@ namespace TE.FileWatcher
             {
                 return ERROR;
             }
+        }
+
+        /// <summary>
+        /// Runs the file/folder watcher as a Windows Service.
+        /// </summary>
+        /// <param name="folder">
+        /// The folder where the config and notifications files are stored.
+        /// </param>
+        /// <param name="configFileName">
+        /// The name of the configuration file.
+        /// </param>
+        /// <returns>
+        /// Returns 0 if no error occurred, otherwise non-zero.
+        /// </returns>
+        [RequiresUnreferencedCode("Calls TE.FileWatcher.Configuration.IConfigurationFile.Read()")]
+        internal static int ServiceMain(string[] args)
+        {
+            HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+            builder.Services.AddWindowsService(options =>
+            {
+                options.ServiceName = "FileWatcher Service";
+            });
+
+            builder.Services.AddHostedService<WindowsBackgroundService>();
+
+            // See: https://github.com/dotnet/runtime/issues/47303
+            builder.Logging.AddConfiguration(builder.Configuration.GetSection("Logging"));
+
+            IHost host = builder.Build();
+            host.Run();
+            return SUCCESS;
         }
 
         /// <summary>
@@ -124,7 +194,7 @@ namespace TE.FileWatcher
         /// <returns>
         /// True if the tasks were started and run successfully, otherwise false.
         /// </returns>
-        private static bool StartWatchers(Watches watches)
+        private static bool StartWatchers(Watches watches, CancellationToken? stoppingToken = null)
         {
             if (watches == null)
             {
@@ -133,10 +203,156 @@ namespace TE.FileWatcher
             }
 
             watches.Start();
-            new AutoResetEvent(false).WaitOne();
+            if (stoppingToken != null)
+            {
+                stoppingToken.Value.WaitHandle.WaitOne();
+            }
+            else
+            {
+                new AutoResetEvent(false).WaitOne(); // Will never return
+            }
 
             Logger.WriteLine("All watchers have closed.");
             return true;
+        }
+
+    }
+
+    public sealed class WindowsBackgroundService : BackgroundService
+    {
+        private readonly ILogger<WindowsBackgroundService> _eventLogger;
+
+        public WindowsBackgroundService(
+            ILogger<WindowsBackgroundService> logger) =>
+                (_eventLogger) = (logger);
+
+        [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "<Pending>")]
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            try
+            {
+                _eventLogger.LogInformation($"CommandLineArgs: {Environment.CommandLine}");
+
+                LoggingConsole loggingConsole = new LoggingConsole(_eventLogger);
+                var errorLogWriter = new ErrorLogWriter(_eventLogger);
+                Console.SetError(errorLogWriter);
+                var result = await Task.Run( () => Program.InitWatcher(Environment.GetCommandLineArgs(), stoppingToken, loggingConsole));
+                if (result != 0)
+                {
+                    errorLogWriter.WriteLine();
+                    _eventLogger.LogError("Process: {ProcessPath}\r\n{Message}", Environment.ProcessPath, $"Service stopped with error: {result}");
+                    Environment.Exit(result);
+                }
+            }
+            catch (TaskCanceledException)
+            {
+                // When the stopping token is canceled, for example, a call made from services.msc,
+                // we shouldn't exit with a non-zero exit code. In other words, this is expected...
+            }
+            catch (Exception ex)
+            {
+                _eventLogger.LogError(ex, "Process: {ProcessPath}\r\n{Message}", Environment.ProcessPath, ex.Message);
+
+                // Terminates this process and returns an exit code to the operating system.
+                // This is required to avoid the 'BackgroundServiceExceptionBehavior', which
+                // performs one of two scenarios:
+                // 1. When set to "Ignore": will do nothing at all, errors cause zombie services.
+                // 2. When set to "StopHost": will cleanly stop the host, and log errors.
+                //
+                // In order for the Windows Service Management system to leverage configured
+                // recovery options, we need to terminate the process with a non-zero exit code.
+                Environment.Exit(1);
+            }
+        }
+        public class LoggingConsole : IConsole
+        {
+            public readonly ILogger<WindowsBackgroundService> _eventLogger;
+
+            public LoggingConsole(ILogger<WindowsBackgroundService> eventLogger) 
+            {
+                this._eventLogger = eventLogger;
+            }
+
+            public IStandardStreamWriter Out => new LoggingStandardWriter(this);
+
+            public bool IsOutputRedirected => true;
+
+            public IStandardStreamWriter Error => new LoggingErrorWriter(this);
+
+            public bool IsErrorRedirected => true;
+
+            public bool IsInputRedirected => false;
+
+            private class LoggingStandardWriter : IStandardStreamWriter
+            {
+                private readonly LoggingConsole _console;
+
+                public LoggingStandardWriter(LoggingConsole console) 
+                {
+                    _console = console;
+                }
+
+                public void Write(string value)
+                {
+                    if (!string.IsNullOrEmpty(value?.Trim()))
+                        _console._eventLogger.LogDebug("Process: {ProcessPath}\r\n{value}", Environment.ProcessPath, value);
+                }
+            }
+            private class LoggingErrorWriter : IStandardStreamWriter
+            {
+                private readonly LoggingConsole _console;
+
+                public LoggingErrorWriter(LoggingConsole console)
+                {
+                    _console = console;
+                }
+                public void Write(string value)
+                {
+                    if (!string.IsNullOrEmpty(value?.Trim()))
+                        _console._eventLogger.LogError("Process: {ProcessPath}\r\n{value}", Environment.ProcessPath, value);
+                }
+            }
+        }
+        public class ErrorLogWriter : TextWriter
+        {
+            public override Encoding Encoding => Encoding.UTF8;
+
+            public readonly ILogger<WindowsBackgroundService> _eventLogger;
+            StringBuilder _message = new StringBuilder();
+
+            public ErrorLogWriter(ILogger<WindowsBackgroundService> eventLogger)
+            {
+                this._eventLogger = eventLogger;
+            }
+
+            public override void Write(string? value)
+            {
+                if (!string.IsNullOrEmpty(value))
+                    _message.Append(value);
+            }
+
+            public override void Write(char ch)
+            {
+                _message.Append(ch);
+            }
+
+            public override void WriteLine(string? value)
+            {
+                if (!string.IsNullOrEmpty(value?.Trim()))
+                {
+                    _message.Append(value);
+                }
+                WriteLine();
+            }
+            public override void WriteLine()
+            {
+                if (_message.Length > 0)
+                {
+                    _eventLogger.LogError("Process: {ProcessPath}\r\n{value}", Environment.ProcessPath, _message);
+                    _message.Clear();
+                }
+            }
+
         }
     }
 }

--- a/FileWatcher/Properties/PublishProfiles/win-x64.pubxml
+++ b/FileWatcher/Properties/PublishProfiles/win-x64.pubxml
@@ -6,11 +6,11 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <Platform>Any CPU</Platform>
-    <PublishDir>bin\Release\net6.0\publish\win-x64</PublishDir>
+    <PublishDir>bin\Release\net6.0\win-x64\publish</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <TargetFramework>net6.0</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
-    <PublishReadyToRun>False</PublishReadyToRun>
+    <PublishReadyToRun>false</PublishReadyToRun>
   </PropertyGroup>
 </Project>

--- a/FileWatcher/appsettings.json
+++ b/FileWatcher/appsettings.json
@@ -1,0 +1,16 @@
+﻿{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning"
+    },
+    "EventLog": {
+      "SourceName": "FileWatcher Service",
+      "LogName": "Application",
+      "LogLevel": {
+        "Microsoft": "Information",
+        "Microsoft.Hosting.Lifetime": "Information",
+        "TE.FileWatcher.WindowsBackgroundService": "Error"
+      }
+    }
+  }
+}

--- a/FwInstaller/FwInstaller.wixproj
+++ b/FwInstaller/FwInstaller.wixproj
@@ -1,0 +1,8 @@
+﻿<Project Sdk="WixToolset.Sdk/4.0.0">
+  <ItemGroup>
+    <None Include="config.xml.sample" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\FileWatcher\FileWatcher.csproj" />
+  </ItemGroup>
+</Project>

--- a/FwInstaller/Package.wxs
+++ b/FwInstaller/Package.wxs
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Define the variables in "$(var.*) expressions" -->
+<?define Name = "FileWatcher Service" ?>
+<?define Manufacturer = "Kåre Smith" ?>
+<?define Version = "1.0.0.0" ?>
+<?define UpgradeCode = "B3D46D88-3D2A-4648-B760-AB1E8C89742C" ?>
+
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+	<Package Name="$(Name)"
+             Manufacturer="$(Manufacturer)"
+             Version="$(Version)"
+             UpgradeCode="$(var.UpgradeCode)"
+             Compressed="true"
+		>
+		<MediaTemplate EmbedCab="yes"/>
+
+		<!-- Allow upgrades and prevent downgrades -->
+		<MajorUpgrade DowngradeErrorMessage="A later version of [ProductName] is already installed. Setup will now exit." />
+
+		<StandardDirectory Id="ProgramFiles6432Folder">
+				<!-- Create a folder inside program files -->
+				<Directory Id="ROOTDIRECTORY" Name="$(var.Manufacturer)">
+
+					<!-- Create a folder within the parent folder given the name -->
+					<Directory Id="INSTALLFOLDER" Name="$(Name)"  />
+				</Directory>
+		</StandardDirectory>
+
+		<!-- The files inside this DirectoryRef are linked to
+             the fw directory via INSTALLFOLDER -->
+		<DirectoryRef Id="INSTALLFOLDER">
+
+			<!-- Create a single component which is the fw.exe file -->
+			<Component Id="ServiceExecutable" Bitness="always64">
+
+				<!-- Copies the fw.exe file using the
+                     project reference preprocessor variables -->
+				<File Id="fw.exe"
+                      Source="$(var.FileWatcher.TargetDir)publish\fw.exe"
+                      KeyPath="true" />
+
+				<File Id="appsettings.json"
+                      Source="$(var.FileWatcher.TargetDir)publish\appsettings.json"
+                      KeyPath="false" />
+
+				<File Id="config.xml"
+					Source="config.xml.sample"
+					KeyPath="false" />
+
+
+				<!-- Remove all files from the INSTALLFOLDER on uninstall -->
+				<RemoveFile Id="ALLFILES" Name="*.*" On="both" />
+
+				<!-- Tell WiX to install the Service -->
+				<ServiceInstall Id="ServiceInstaller"
+                                Type="ownProcess"
+                                Name="$(Name)"
+                                DisplayName="$(Name)"
+                                Description="Monitors files and folders for changes"
+                                Start="auto"
+                                ErrorControl="normal" />
+
+				<!-- Tell WiX to start the Service  Start="install" -->
+				<ServiceControl Id="StartService"
+                                Stop="both"
+                                Remove="uninstall"
+                                Name="$(Name)"
+                                Wait="true" />
+			</Component>
+		</DirectoryRef>
+
+		<!-- Tell WiX to install the files -->
+		<Feature Id="Service" Title="$(Name) Setup" Level="1">
+			<ComponentRef Id="ServiceExecutable" />
+		</Feature>
+
+	</Package>
+</Wix>

--- a/FwInstaller/config.xml.sample
+++ b/FwInstaller/config.xml.sample
@@ -1,0 +1,290 @@
+<watches>
+    <logging>
+        <!--
+            The full path to the log file.
+
+            Default: %TEMP%\fw.log
+        -->
+        <path>c:\temp\fw.log</path>
+        <!--
+            The maximum size (in MB) of the log file before it is backed up and a
+            new log file is created. Cannot be left blank.
+
+            Default: 5
+        -->
+        <size>5</size>
+        <!--
+            The number of log files to keep. Once this number is reached, old log
+            files are deleted. Cannot be left blank.
+
+            Default: 10
+        -->
+        <number>10</number>
+    </logging>
+    <!-- A folder watch-->
+	<watch>
+        <!-- 
+            Path of the folder to watch. File and folder exclusions are relative
+            to the value specified in this element.
+        -->
+        <path>c:\temp\test</path>
+        <!--
+            The amount of seconds to wait for the path to exist before
+            establishing the watch. This timeout can be used with paths that
+            are on external hard drives that may not be connected for a time
+            when FileWatcher is started.
+        -->
+        <timeout>1</timeout>
+        <filters>
+            <!-- 
+                Filters matching file name. The full name of a file,
+                regardless of which folder it is included in, is matched.
+             -->
+            <files>
+                <name></name>
+            </files>
+            <!-- 
+                Filters matching folder names. The folder names are relative
+                to the path element. For example, if path is C:\Temp and a name
+                is TestFolder, then the folder C:\Temp\TestFolder is matched.
+            -->
+            <folders>
+                <name></name>
+            </folders>
+            <!-- 
+                Filters matching folder/file attributes. The filters are
+                matched if a file contains any of the attributes specified.
+
+                Valid values:
+                    Archive
+                    Compressed
+                    Encrypted
+                    Hidden
+                    ReadOnly
+                    System
+            -->
+            <attributes>
+                <attribute></attribute>
+            </attributes>
+            <!-- 
+                Filters matching full paths. Similar to the folder names,
+                paths are relative to the path element and allow for exact file
+                path matching - for example, to include C:\Temp\TestFolder\thumbs.db,
+                specify TestFolder\thumbs.db.
+            -->
+            <paths>
+                <path></path>
+            </paths>
+        </filters>        
+        <exclusions>
+            <!-- 
+                Exclusions matching file name. The full name of a file,
+                regardless of which folder it is included in, is excluded.
+             -->
+            <files>
+                <name>ExcludeThis</name>
+            </files>
+            <!-- 
+                Exclusions matching folder names. The folder names are relative
+                to the path element. For example, if path is C:\Temp and a name
+                is TestFolder, then the folder C:\Temp\TestFolder is excluded.
+            -->
+            <folders>
+                <name>ExcludeThis</name>
+            </folders>
+            <!-- 
+                Exclusions matching folder/file attributes. The exclusions are
+                matched if a file contains any of the attributes specified.
+
+                Valid values:
+                    Archive
+                    Compressed
+                    Encrypted
+                    Hidden
+                    ReadOnly
+                    System
+            -->
+            <attributes>
+                <attribute></attribute>
+            </attributes>
+            <!-- 
+                Exclusions matching full paths. Similar to the folder names,
+                paths are relative to the path element and allow for exact file
+                path matching - for example, to exclude C:\Temp\TestFolder\thumbs.db,
+                specify TestFolder\thumbs.db.
+            -->
+            <paths>
+                <path>ExcludeThis</path>
+            </paths>
+        </exclusions>
+        <notifications>
+            <!-- 
+                Time, in milliseconds, to wait between he notification send request.
+                If no value is specified, then 60000 (1 minute) will be used. Any
+                value lower than 30000 (30 seconds) will be set to 30000.
+            -->
+            <waittime>30000</waittime>
+            <notification>
+                <url></url>
+                <!--
+                    What method will be used to send the notification.
+
+                    Values:
+                        DELETE
+                        GET
+                        POST (default)
+                        PUT
+                -->        
+                <method></method>
+                <!--
+                    What events will trigger the notificaton.
+
+                    Values:
+                        Change
+                        Create
+                        Delete
+                        Rename
+                -->
+                <triggers>
+                    <trigger></trigger>
+                </triggers>
+                <data>
+                    <headers>
+                        <header>
+                            <name></name>
+                            <value></value>
+                        </header>
+                    </headers>
+                    <!--
+                        Placeholders:
+                            [message] - messsage of the change
+                    -->
+                    <body></body>
+                    <!--
+                        The type of request.
+
+                        Values:
+                            JSON (default)
+                            XML
+                    -->
+                    <type></type>            
+                </data>
+            </notification>
+        </notifications>
+        <!--
+            Perform actions when a change is detected.
+        -->
+        <actions>
+            <action>
+                <!--
+                    What events will trigger the action.
+
+                    Values:
+                        Change
+                        Create
+                        Delete
+                        Rename
+                -->
+                <triggers>
+                    <trigger>Change</trigger>
+                </triggers>            
+                <!--
+                    The type of action to perform.
+
+                    Values:
+                        Copy
+                        Move
+                        Delete
+                -->
+                <type>Copy</type>
+                <!--
+                    The source path of the action. 
+
+                    Placeholders:
+                        [exactpath] - full path of the changed file
+                        [fullpath] - full path of the changed file without the path of the watch
+                        [path] - the path of the changed file without the path of the watch and the file
+                        [file] - the name of the file with the extension
+                        [filename] - name of the file without the extension
+                        [extension] - the file extension
+                -->
+                <source>[exactpath]</source>
+                <!--
+                    The destination path of the action.
+                    This value does not apply to the Delete action.
+
+                    Placeholders:
+                        [exactpath] - full path of the changed file
+                        [fullpath] - full path of the changed file without the path of the watch
+                        [path] - the path of the changed file without the path of the watch and the file
+                        [file] - the name of the file with the extension
+                        [filename] - name of the file without the extension
+                        [extension] - the file extension
+                        [createddate:format]
+                        [modifieddate:format]
+                        [currentdate:format]
+                -->
+                <destination>c:\temp\dest\[file]</destination>
+                <!--
+                    Verifies the file after a copy or move.
+
+                    Values:
+                        true
+                        false (default)
+                -->
+              <verify>false</verify>
+              <!--
+                Keeps the creation and modified timestamps of the source file and applies
+                them to the destination file.
+                Values:
+                    true
+                    false (default)                    
+              -->
+              <keepTimestamps>true</keepTimestamps>
+            </action>
+        </actions>
+        <!--
+            Run commands when a change is detected.
+        -->
+        <commands>
+            <command>
+                <!--
+                    What events will trigger the command.
+
+                    Values:
+                        Change
+                        Create
+                        Delete
+                        Rename
+                -->
+                <triggers>
+                    <trigger></trigger>
+                </triggers>            
+                <!--
+                    The path of the command to run.
+
+                    Placeholders:
+                        [exactpath] - full path of the changed file
+                        [fullpath] - full path of the changed file without the path of the watch
+                        [path] - the path of the changed file without the path of the watch and the file
+                        [file] - the name of the file with the extension
+                        [filename] - name of the file without the extension
+                        [extension] - the file extension
+                -->            
+                <path></path>
+                <!--
+                    The arguments of the command to run.
+                    
+                    Placeholders:                    
+                        [exactpath] - full path of the changed file
+                        [fullpath] - full path of the changed file without the path of the watch
+                        [path] - the path of the changed file without the path of the watch and the file
+                        [file] - the name of the file with the extension
+                        [filename] - name of the file without the extension
+                        [extension] - the file extension
+                -->                   
+                <arguments></arguments>
+            </command>
+        </commands>    
+    </watch>
+</watches>


### PR DESCRIPTION
Often FileWatching is something one want to have as a service started on boot of the machine. On Windows both a Scheduled Task and a Service may be used for this. With .NET it is quite easy to make the program runnable as a Windows service. Configuring a Scheduled Task is quite complex, while installing a service is quite easy.

See [Windows-Service](https://learn.microsoft.com/en-us/dotnet/core/extensions/windows-service?pivots=dotnet-6-0).
To make installation even easier, I added a installer project using Wix 4. For the Wix project to build, Wix must be installed (dotnet tool install --global wix), as well as HeatWave for VS2022.

Please see if any of the ideas might be implemented in the new FileWatcher version in development.

One complaint from the users is logging, where the UTF-8 encoded logfile is without a BOM -  Byte Order Marker. This makes some text editors and log viewers on Windows misunderstand the encoding so international characters are shown wrong. I made a minor change to Logger.cs, to make it create a BOM for logfiles on Windows.
