### PR TITLE
Removed requirement for write access to the configuration file

### DIFF
--- a/FileWatcher/Configuration/XmlFile.cs
+++ b/FileWatcher/Configuration/XmlFile.cs
@@ -142,7 +142,7 @@ namespace TE.FileWatcher.Configuration
             try
             {
                 XmlSerializer serializer = new(typeof(Watches));
-                using FileStream fs = new(_fullPath, FileMode.Open);
+                using FileStream fs = new(_fullPath, FileMode.Open, FileAccess.Read);
                 return (Watches?)serializer.Deserialize(fs);
             }
             catch (Exception ex)

--- a/FileWatcher/FileWatcher.csproj
+++ b/FileWatcher/FileWatcher.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>    
     <RootNamespace>TE.FileWatcher</RootNamespace>
     <AssemblyName>fw</AssemblyName>
-    <Version>1.4.90</Version>
+    <Version>1.4.91</Version>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
     <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>

--- a/FwInstaller/Package.wxs
+++ b/FwInstaller/Package.wxs
@@ -3,7 +3,7 @@
 <!-- Define the variables in "$(var.*) expressions" -->
 <?define Name = "FileWatcher Service" ?>
 <?define Manufacturer = "Kåre Smith" ?>
-<?define Version = "1.0.0.0" ?>
+<?define Version = "1.0.0.1" ?>
 <?define UpgradeCode = "B3D46D88-3D2A-4648-B760-AB1E8C89742C" ?>
 
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">


### PR DESCRIPTION
The program opened the configuration file for both read and write access, while only read access is needed, and in some scenarios, the program will only have read access, and will fail.